### PR TITLE
Version 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] / 2023-04-17
+### UI
+- Update `NewPushButtonData` the default `Text` equals to `targetName`.
+### Tests
+- Add `RevitCreateItemsCommandTests`
+- Add `RevitCreateItemsCommandSetTests`
+- Update `RevitCreateItemsWithNameTests`
+
 ## [0.5.1] / 2023-04-14
 ### RibbonStackExtension
 - Add RowStackedItems

--- a/ricaun.Revit.UI.Example/ricaun.Revit.UI.Example.csproj
+++ b/ricaun.Revit.UI.Example/ricaun.Revit.UI.Example.csproj
@@ -76,7 +76,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Revit.UI.Example</PackageId>
-    <Version>1.5.1</Version>
+    <Version>1.5.2</Version>
     <ProjectGuid>{f736f68f-7101-4640-9093-8715f88ccb95}</ProjectGuid>
   </PropertyGroup>
 

--- a/ricaun.Revit.UI.Tests/Items/Commands/RevitCreateItemsCommandSetTests.cs
+++ b/ricaun.Revit.UI.Tests/Items/Commands/RevitCreateItemsCommandSetTests.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Framework;
+
+namespace ricaun.Revit.UI.Tests.Items.Commands
+{
+    public class RevitCreateItemsCommandSetTests : BaseCreatePanelTests
+    {
+        [TestCase("Text")]
+        [TestCase("Command")]
+        public void CreatePushButton_Text(string text)
+        {
+            var ribbonItem = ribbonPanel.CreatePushButton<BaseCommand>(text);
+            Assert.AreEqual(text, ribbonItem.ItemText);
+        }
+
+        [TestCase("Text")]
+        [TestCase("Command")]
+        public void CreatePushButton_SetText(string text)
+        {
+            var ribbonItem = ribbonPanel.CreatePushButton<BaseCommand>()
+                .SetText(text);
+            Assert.AreEqual(text, ribbonItem.ItemText);
+        }
+
+        [TestCase("Tip")]
+        [TestCase("ToolTip")]
+        public void CreatePushButton_SetToolTip(string toolTip)
+        {
+            var ribbonItem = ribbonPanel.CreatePushButton<BaseCommand>()
+                .SetToolTip(toolTip);
+            Assert.AreEqual(toolTip, ribbonItem.ToolTip);
+        }
+
+        [TestCase("Description")]
+        [TestCase("LongDescription")]
+        public void CreatePushButton_SetLongDescription(string longDescription)
+        {
+            var ribbonItem = ribbonPanel.CreatePushButton<BaseCommand>()
+                .SetLongDescription(longDescription);
+            Assert.AreEqual(longDescription, ribbonItem.LongDescription);
+        }
+    }
+}

--- a/ricaun.Revit.UI.Tests/Items/Commands/RevitCreateItemsCommandTests.cs
+++ b/ricaun.Revit.UI.Tests/Items/Commands/RevitCreateItemsCommandTests.cs
@@ -1,0 +1,44 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace ricaun.Revit.UI.Tests.Items.Commands
+{
+    public class RevitCreateItemsCommandTests : BaseCreatePanelTests
+    {
+        [Test]
+        public void CreatePushButton()
+        {
+            var ribbonItem = ribbonPanel.CreatePushButton<BaseCommand>();
+            Console.WriteLine(ribbonItem.Name);
+            Assert.AreEqual(nameof(BaseCommand), ribbonItem.Name);
+            Assert.AreEqual(nameof(BaseCommand), ribbonItem.ItemText);
+        }
+
+        [Test]
+        public void NewPushButtonData()
+        {
+            var ribbonItem = ribbonPanel.NewPushButtonData<BaseCommand>();
+            Console.WriteLine(ribbonItem.Name);
+            Assert.AreEqual(nameof(BaseCommand), ribbonItem.Name);
+            Assert.AreEqual(nameof(BaseCommand), ribbonItem.Text);
+        }
+
+        [Test]
+        public void NewPushButtonData_Type()
+        {
+            var ribbonItem = ribbonPanel.NewPushButtonData(typeof(BaseCommand));
+            Console.WriteLine(ribbonItem.Name);
+            Assert.AreEqual(nameof(BaseCommand), ribbonItem.Name);
+            Assert.AreEqual(nameof(BaseCommand), ribbonItem.Text);
+        }
+
+        [Test]
+        public void NewToggleButtonData()
+        {
+            var ribbonItem = ribbonPanel.NewToggleButtonData<BaseCommand>();
+            Console.WriteLine(ribbonItem.Name);
+            Assert.AreEqual(nameof(BaseCommand), ribbonItem.Name);
+            Assert.AreEqual(nameof(BaseCommand), ribbonItem.Text);
+        }
+    }
+}

--- a/ricaun.Revit.UI.Tests/Items/RevitCreateItemsWithNameTests.cs
+++ b/ricaun.Revit.UI.Tests/Items/RevitCreateItemsWithNameTests.cs
@@ -4,6 +4,7 @@ namespace ricaun.Revit.UI.Tests.Items
 {
     public class RevitCreateItemsWithNameTests : BaseCreatePanelTests
     {
+        [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]
         [TestCase("Name")]
@@ -12,6 +13,7 @@ namespace ricaun.Revit.UI.Tests.Items
             ribbonPanel.CreateComboBox(name);
         }
 
+        [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]
         [TestCase("Name")]
@@ -20,6 +22,7 @@ namespace ricaun.Revit.UI.Tests.Items
             ribbonPanel.CreatePulldownButton(name);
         }
 
+        [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]
         [TestCase("Name")]
@@ -28,6 +31,7 @@ namespace ricaun.Revit.UI.Tests.Items
             ribbonPanel.CreatePushButton<BaseCommand>(name);
         }
 
+        [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]
         [TestCase("Name")]
@@ -36,6 +40,7 @@ namespace ricaun.Revit.UI.Tests.Items
             ribbonPanel.CreateRadioButtonGroup(name);
         }
 
+        [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]
         [TestCase("Name")]
@@ -44,6 +49,7 @@ namespace ricaun.Revit.UI.Tests.Items
             ribbonPanel.CreateSplitButton(name);
         }
 
+        [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]
         [TestCase("Name")]
@@ -52,7 +58,4 @@ namespace ricaun.Revit.UI.Tests.Items
             ribbonPanel.CreateTextBox(name);
         }
     }
-
-
-
 }

--- a/ricaun.Revit.UI/RibbonSafeExtension.cs
+++ b/ricaun.Revit.UI/RibbonSafeExtension.cs
@@ -124,7 +124,7 @@ namespace ricaun.Revit.UI
                 buttonData.AvailabilityClassName = commandType.FullName;
 
             if (string.IsNullOrWhiteSpace(text))
-                buttonData.Text = SafeMinimalText;
+                buttonData.Text = targetName;
 
             return buttonData;
         }

--- a/ricaun.Revit.UI/ricaun.Revit.UI.csproj
+++ b/ricaun.Revit.UI/ricaun.Revit.UI.csproj
@@ -76,7 +76,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Revit.UI</PackageId>
-    <Version>0.5.1</Version>
+    <Version>0.5.2</Version>
     <ProjectGuid>{2064ba4d-5527-41e9-8b76-0cbfefa35900}</ProjectGuid>
   </PropertyGroup>
 


### PR DESCRIPTION
### UI
- Update `NewPushButtonData` the default `Text` equals to `targetName`. 
### Tests
- Add `RevitCreateItemsCommandTests`
- Add `RevitCreateItemsCommandSetTests`
- Update `RevitCreateItemsWithNameTests`