### PR TITLE
Version 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] / 2026-06-18
+### Features
+### Updates
+- Update `RibbonTabExtension` to `RemoveWhenEmptyAndNotActiveTab` when `RibbonTab` is empty.
+
 ## [0.9.0] / 2026-04-06 - 2026-04-10
 ### Features
 - Support `Revit 2027` and `Revit Preview`.
@@ -409,6 +414,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release
 
 [vNext]: ../../compare/1.0.0...HEAD
+[0.9.1]: ../../compare/0.9.0...0.9.1
 [0.9.0]: ../../compare/0.8.0...0.9.0
 [0.8.0]: ../../compare/0.7.1...0.8.0
 [0.7.1]: ../../compare/0.7.0...0.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.9.1] / 2026-06-18
 ### Features
 ### Updates
+- Update `RibbonTabExtension` to use `RibbonControl` property.
+- Update `RibbonTabExtension` to check if `RibbonControl` is null before accessing it.
 - Update `RibbonTabExtension` to `RemoveWhenEmptyAndNotActiveTab` when `RibbonTab` is empty.
 
 ## [0.9.0] / 2026-04-06 - 2026-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `RibbonTabExtension` to `RemoveWhenEmptyAndNotActiveTab` when `RibbonTab` is empty.
 - Update `RibbonPanelExtension` to use `RibbonTabExtension.RibbonControl` to find `RibbonTab`.
 - Update `RibbonControl` to fallback to `UIFramework.RevitRibbonControl.RibbonControl`.
+- Update `SetAutodeskOwner` to check if `Window` is valid before setting owner.
 
 ## [0.9.0] / 2026-04-06 - 2026-04-10
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Features
 ### Updates
 - Update `RibbonTabExtension` to use `RibbonControl` property.
-- Update `RibbonTabExtension` to check if `RibbonControl` is null before accessing it.
+- Update `RibbonTabExtension` to check if `RibbonControl` is null before accessing it. (Fix: #41)
 - Update `RibbonTabExtension` to `RemoveWhenEmptyAndNotActiveTab` when `RibbonTab` is empty.
 
 ## [0.9.0] / 2026-04-06 - 2026-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.9.1] / 2026-06-18
 ### Features
+- Support `RibbonControl` when Revit is closing.
 ### Updates
 - Update `RibbonTabExtension` to use `RibbonControl` property.
 - Update `RibbonTabExtension` to check if `RibbonControl` is null before accessing it. (Fix: #41)
 - Update `RibbonTabExtension` to `RemoveWhenEmptyAndNotActiveTab` when `RibbonTab` is empty.
+- Update `RibbonPanelExtension` to use `RibbonTabExtension.RibbonControl` to find `RibbonTab`.
+- Update `RibbonControl` to fallback to `UIFramework.RevitRibbonControl.RibbonControl`.
 
 ## [0.9.0] / 2026-04-06 - 2026-04-10
 ### Features

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.9.0</Version>
+		<Version>0.9.1-alpha</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.9.1-beta</Version>
+		<Version>0.9.1-beta.1</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.9.1-rc</Version>
+		<Version>0.9.1</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.9.1-alpha</Version>
+		<Version>0.9.1-beta</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.9.1-beta.1</Version>
+		<Version>0.9.1-rc</Version>
 	</PropertyGroup>
 </Project>

--- a/ricaun.Revit.UI.Example/ricaun.Revit.UI.Example.csproj
+++ b/ricaun.Revit.UI.Example/ricaun.Revit.UI.Example.csproj
@@ -61,6 +61,13 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
 
+  <!-- DebugRevitVersion -->
+  <PropertyGroup Condition="$(Configuration.Contains('Debug'))">
+    <DebugRevitVersion>$(RevitVersion)</DebugRevitVersion>
+    <StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files\Autodesk\Revit $(DebugRevitVersion)\Revit.exe</StartProgram>
+  </PropertyGroup>
+
   <PropertyGroup>
     <PackageId>ricaun.Revit.UI.Example</PackageId>
     <Version Condition="'$(Version)' == ''">0.6.0</Version>

--- a/ricaun.Revit.UI/AutodeskExtension.cs
+++ b/ricaun.Revit.UI/AutodeskExtension.cs
@@ -24,8 +24,14 @@ namespace ricaun.Revit.UI
         /// Set Autodesk.Windows as the Owner of the Window and Active Autodesk.Windows when Closed
         /// </summary>
         /// <param name="window"></param>
+#if NET46
+        [Obsolete("This function does not work with Revit 2018 and 2017, Revit Application is not a Window.")]
+#endif
         public static void SetAutodeskOwner(this Window window)
         {
+            if (GetAutodeskOwner() is null)
+                return;
+
             new WindowInteropHelper(window) { Owner = ComponentManager.ApplicationWindow };
             window.Closed += (s, e) => { SetForegroundWindow(ComponentManager.ApplicationWindow); };
         }
@@ -35,7 +41,7 @@ namespace ricaun.Revit.UI
         /// </summary>
         /// <returns></returns>
 #if NET46
-        [Obsolete("This funciton does not work with Revit 2018 and 2017, Revit Application is not a Window.")]
+        [Obsolete("This function does not work with Revit 2018 and 2017, Revit Application is not a Window.")]
 #endif
         public static Window GetAutodeskOwner()
         {

--- a/ricaun.Revit.UI/RibbonPanelExtension.cs
+++ b/ricaun.Revit.UI/RibbonPanelExtension.cs
@@ -151,8 +151,8 @@ namespace ricaun.Revit.UI
         /// <remarks>The <paramref name="ribbonPanel"/> is removed from the original RibbonTab using <see cref="RibbonTabExtension.Remove(Autodesk.Windows.RibbonTab, Autodesk.Windows.RibbonPanel)"/></remarks>
         public static RibbonPanel MoveToRibbonTab(this RibbonPanel ribbonPanel, string ribbonTabId)
         {
-            var ribbonTab = Autodesk.Windows.ComponentManager.Ribbon.FindTab(ribbonTabId);
-            return ribbonPanel.MoveToRibbonTab(ribbonTab);
+            var ribbonTab = RibbonTabExtension.RibbonControl?.FindTab(ribbonTabId);
+            return ribbonPanel?.MoveToRibbonTab(ribbonTab);
         }
 
         /// <summary>

--- a/ricaun.Revit.UI/RibbonTabExtension.cs
+++ b/ricaun.Revit.UI/RibbonTabExtension.cs
@@ -14,9 +14,10 @@ namespace ricaun.Revit.UI
         /// Get RibbonControl in Revit
         /// </summary>
         /// <remarks>
-        /// RibbonControl can be null when Revit is closing.
+        /// <see cref="Autodesk.Windows.ComponentManager.Ribbon"/> can be null when Revit is closing and 
+        /// <see cref="UIFramework.RevitRibbonControl.RibbonControl"/> could be used as a fallback.
         /// </remarks>
-        internal static Autodesk.Windows.RibbonControl RibbonControl => Autodesk.Windows.ComponentManager.Ribbon;
+        internal static Autodesk.Windows.RibbonControl RibbonControl => Autodesk.Windows.ComponentManager.Ribbon ?? UIFramework.RevitRibbonControl.RibbonControl;
         #region Select
         /// <summary>
         /// GetRibbonTab

--- a/ricaun.Revit.UI/RibbonTabExtension.cs
+++ b/ricaun.Revit.UI/RibbonTabExtension.cs
@@ -10,6 +10,13 @@ namespace ricaun.Revit.UI
     /// </summary>
     public static class RibbonTabExtension
     {
+        /// <summary>
+        /// Get RibbonControl in Revit
+        /// </summary>
+        /// <remarks>
+        /// RibbonControl can be null when Revit is closing.
+        /// </remarks>
+        internal static Autodesk.Windows.RibbonControl RibbonControl => Autodesk.Windows.ComponentManager.Ribbon;
         #region Select
         /// <summary>
         /// GetRibbonTab
@@ -28,8 +35,7 @@ namespace ricaun.Revit.UI
         /// <returns></returns>
         public static Autodesk.Windows.RibbonTab GetRibbonTab(string ribbonTabId)
         {
-            var ribbon = Autodesk.Windows.ComponentManager.Ribbon;
-            return ribbon.FindTab(ribbonTabId);
+            return RibbonControl?.FindTab(ribbonTabId);
         }
 
         /// <summary>
@@ -38,8 +44,7 @@ namespace ricaun.Revit.UI
         /// <returns></returns>
         public static IList<Autodesk.Windows.RibbonTab> GetRibbonTabs()
         {
-            var ribbon = Autodesk.Windows.ComponentManager.Ribbon;
-            return ribbon.Tabs;
+            return RibbonControl?.Tabs;
         }
         #endregion
 
@@ -51,9 +56,12 @@ namespace ricaun.Revit.UI
         /// <returns></returns>
         public static bool Remove(this Autodesk.Windows.RibbonTab ribbonTab)
         {
-            var ribbon = Autodesk.Windows.ComponentManager.Ribbon;
             GetRibbonTabsDictionary()?.Remove(ribbonTab.Id);
-            return ribbon.Tabs.Remove(ribbonTab);
+
+            if (RibbonControl is null)
+                return false;
+
+            return RibbonControl.Tabs.Remove(ribbonTab);
         }
 
         /// <summary>

--- a/ricaun.Revit.UI/RibbonTabExtension.cs
+++ b/ricaun.Revit.UI/RibbonTabExtension.cs
@@ -60,9 +60,13 @@ namespace ricaun.Revit.UI
         /// Remove Tab When Empty / Remove Revit Dictionary Name
         /// </summary>
         /// <param name="ribbonTab"></param>
-        internal static void RemoveWhenEmpty(this Autodesk.Windows.RibbonTab ribbonTab)
+        internal static void RemoveWhenEmptyAndNotActiveTab(this Autodesk.Windows.RibbonTab ribbonTab)
         {
             if (ribbonTab is null) return;
+
+            if (RibbonControl?.ActiveTab == ribbonTab)
+                return;
+
             if (ribbonTab.Panels.Count == 0)
             {
                 ribbonTab.Remove();
@@ -79,7 +83,7 @@ namespace ricaun.Revit.UI
         {
             var removed = ribbonTab.Panels.Remove(ribbonPanel);
             RibbonTabsDictionaryRemove(ribbonTab.Id, ribbonPanel.Source.Name);
-            ribbonTab.RemoveWhenEmpty();
+            ribbonTab.RemoveWhenEmptyAndNotActiveTab();
             return removed;
         }
 


### PR DESCRIPTION
### Features
- Support `RibbonControl` when Revit is closing.
### Updates
- Update `RibbonTabExtension` to use `RibbonControl` property.
- Update `RibbonTabExtension` to check if `RibbonControl` is null before accessing it. (Fix: #41)
- Update `RibbonTabExtension` to `RemoveWhenEmptyAndNotActiveTab` when `RibbonTab` is empty.
- Update `RibbonPanelExtension` to use `RibbonTabExtension.RibbonControl` to find `RibbonTab`.
- Update `RibbonControl` to fallback to `UIFramework.RevitRibbonControl.RibbonControl`.
- Update `SetAutodeskOwner` to check if `Window` is valid before setting owner.